### PR TITLE
Update CSP.conf comments: CSP On enables the Management Portal

### DIFF
--- a/demo-compose/webgateway/CSP.conf
+++ b/demo-compose/webgateway/CSP.conf
@@ -3,8 +3,7 @@
 CSPModulePath "${ISC_PACKAGE_INSTALLDIR}/bin/"
 CSPConfigPath "${ISC_PACKAGE_INSTALLDIR}/bin/"
 
-# Serve everything via Web Gateway. Conveniently,
-# we needn't worry about sharing this container with non-IRIS applications.
+# Serve everything via Web Gateway. This enables access to the Management Portal.
 <Location />
     CSP On
 </Location>

--- a/demo-dockerfile/CSP.conf
+++ b/demo-dockerfile/CSP.conf
@@ -5,7 +5,7 @@ CSPModulePath /home/irisowner/webgateway/bin/
 CSPConfigPath /home/irisowner/webgateway/bin/
 LoadModule csp_module_sa /home/irisowner/webgateway/bin/CSPa24.so
 
-# Serve everything via Web Gateway.
+# Serve everything via Web Gateway. This enables access to the Management Portal.
 <Location />
     CSP On
 </Location>

--- a/demo-many-to-many/webgateway/CSP_sidecars.conf
+++ b/demo-many-to-many/webgateway/CSP_sidecars.conf
@@ -3,7 +3,7 @@
 CSPModulePath "${ISC_PACKAGE_INSTALLDIR}/bin/"
 CSPConfigPath "${ISC_PACKAGE_INSTALLDIR}/bin/"
 
-# Serve everything via Web Gateway
+# Serve everything via Web Gateway. This enables access to the Management Portal.
 <Location />
     CSP On
 # To restrict traffic to specific IPs (e.g. for admins' machines),

--- a/demo-one-to-many/webgateway/CSP.conf
+++ b/demo-one-to-many/webgateway/CSP.conf
@@ -3,7 +3,7 @@
 CSPModulePath "${ISC_PACKAGE_INSTALLDIR}/bin/"
 CSPConfigPath "${ISC_PACKAGE_INSTALLDIR}/bin/"
 
-# Serve everything via Web Gateway
+# Serve everything via Web Gateway. This enables access to the Management Portal.
 <Location />
     CSP On
 </Location>


### PR DESCRIPTION
Some customers don't know that CSP On is required to enable the Management Portal, so I added a clarifying comment to the file.